### PR TITLE
Work around inserting so many dummy G4 commands

### DIFF
--- a/octoprint_m3dfio/__init__.py
+++ b/octoprint_m3dfio/__init__.py
@@ -77,6 +77,7 @@ class M3DFioPlugin(
 		self.invalidBedOrientation = False
 		self.slicerChanges = None
 		self.sharedLibrary = None
+		self.commandBacklog = []
 		
 		# Rom decryption and encryption tables
 		self.romDecryptionTable = [0x26, 0xE2, 0x63, 0xAC, 0x27, 0xDE, 0x0D, 0x94, 0x79, 0xAB, 0x29, 0x87, 0x14, 0x95, 0x1F, 0xAE, 0x5F, 0xED, 0x47, 0xCE, 0x60, 0xBC, 0x11, 0xC3, 0x42, 0xE3, 0x03, 0x8E, 0x6D, 0x9D, 0x6E, 0xF2, 0x4D, 0x84, 0x25, 0xFF, 0x40, 0xC0, 0x44, 0xFD, 0x0F, 0x9B, 0x67, 0x90, 0x16, 0xB4, 0x07, 0x80, 0x39, 0xFB, 0x1D, 0xF9, 0x5A, 0xCA, 0x57, 0xA9, 0x5E, 0xEF, 0x6B, 0xB6, 0x2F, 0x83, 0x65, 0x8A, 0x13, 0xF5, 0x3C, 0xDC, 0x37, 0xD3, 0x0A, 0xF4, 0x77, 0xF3, 0x20, 0xE8, 0x73, 0xDB, 0x7B, 0xBB, 0x0B, 0xFA, 0x64, 0x8F, 0x08, 0xA3, 0x7D, 0xEB, 0x5C, 0x9C, 0x3E, 0x8C, 0x30, 0xB0, 0x7F, 0xBE, 0x2A, 0xD0, 0x68, 0xA2, 0x22, 0xF7, 0x1C, 0xC2, 0x17, 0xCD, 0x78, 0xC7, 0x21, 0x9E, 0x70, 0x99, 0x1A, 0xF8, 0x58, 0xEA, 0x36, 0xB1, 0x69, 0xC9, 0x04, 0xEE, 0x3B, 0xD6, 0x34, 0xFE, 0x55, 0xE7, 0x1B, 0xA6, 0x4A, 0x9A, 0x54, 0xE6, 0x51, 0xA0, 0x4E, 0xCF, 0x32, 0x88, 0x48, 0xA4, 0x33, 0xA5, 0x5B, 0xB9, 0x62, 0xD4, 0x6F, 0x98, 0x6C, 0xE1, 0x53, 0xCB, 0x46, 0xDD, 0x01, 0xE5, 0x7A, 0x86, 0x75, 0xDF, 0x31, 0xD2, 0x02, 0x97, 0x66, 0xE4, 0x38, 0xEC, 0x12, 0xB7, 0x00, 0x93, 0x15, 0x8B, 0x6A, 0xC5, 0x71, 0x92, 0x45, 0xA1, 0x59, 0xF0, 0x06, 0xA8, 0x5D, 0x82, 0x2C, 0xC4, 0x43, 0xCC, 0x2D, 0xD5, 0x35, 0xD7, 0x3D, 0xB2, 0x74, 0xB3, 0x09, 0xC6, 0x7C, 0xBF, 0x2E, 0xB8, 0x28, 0x9F, 0x41, 0xBA, 0x10, 0xAF, 0x0C, 0xFC, 0x23, 0xD9, 0x49, 0xF6, 0x7E, 0x8D, 0x18, 0x96, 0x56, 0xD1, 0x2B, 0xAD, 0x4B, 0xC1, 0x4F, 0xC8, 0x3A, 0xF1, 0x1E, 0xBD, 0x4C, 0xDA, 0x50, 0xA7, 0x52, 0xE9, 0x76, 0xD8, 0x19, 0x91, 0x72, 0x85, 0x3F, 0x81, 0x61, 0xAA, 0x05, 0x89, 0x0E, 0xB5, 0x24, 0xE0]
@@ -132,7 +133,7 @@ class M3DFioPlugin(
 		# General settings
 		self.preprocessOnTheFlyReady = False
 		self.printingTestBorder = False
-		self.changedCommands = []
+		self.changedCommands = {}
 		
 		# Center model pre-processor settings
 		self.displacementX = 0
@@ -582,6 +583,9 @@ class M3DFioPlugin(
 		
 		# Restore files
 		self.restoreFiles()
+
+		# dump command backlog
+		self.commandBacklog = []
 	
 	# Get default settings
 	def get_settings_defaults(self) :
@@ -1622,6 +1626,9 @@ class M3DFioPlugin(
 			# Set data
 			data = "M0\n"
 		
+			# dump command backlog
+			self.commandBacklog = []
+
 		# Check if request ends waiting
 		if "M65536" in data :
 			
@@ -1663,16 +1670,43 @@ class M3DFioPlugin(
 					
 						# Pre-process command
 						commands = self.preprocess(data)
-				
-					# Send pre-processed commands to the printer
-					self._printer.commands(commands)
+
+					#self._logger.info("preprocessing {0} yields {1}".format(data[:-1], commands))
+					# add commands to backlog
+					if commands == [""] :
+						# skip command
+						pass
 					
-					# Store changed command
-					self.changedCommands += [lineNumber]
-				
-				# Change command
-				data = 'N' + str(lineNumber) + " G4"
-			
+					else :
+						self.commandBacklog += commands
+
+						# add extra commands to the queue
+						if len(commands) > 1 :
+							self._printer.commands(["G4 *" for cmd in commands[:-1]])
+
+				else :
+					# resend of replaced command
+					data = self.changedCommands[lineNumber]
+					self.commandBacklog = [data] + self.commandBacklog
+
+			elif "G4 *" in data :
+				# extract line number from dummy command
+				lineNumber = int(re.findall("^N(\d+)", data)[0])
+
+                        else :
+				# add command to backlog
+				#self._logger.info("adding {0}".format(data[:-1]))
+				self.commandBacklog.append(data)
+
+			# Work through backlog
+			#self._logger.info("backlog = {0}".format(self.commandBacklog))
+			if self.commandBacklog :
+				data = self.commandBacklog[0]
+				self.commandBacklog = self.commandBacklog[1:]
+
+			else :
+				data = "G4"
+
 			# Check if command contains valid G-code
 			if gcode.parseLine(data) :
 	
@@ -1682,9 +1716,13 @@ class M3DFioPlugin(
 					# Reset number wrap counter
 					self.numberWrapCounter = 0
 				
-				# Get the command's binary representation
+				# Fix line number and get the command's binary representation
+				if lineNumber is not None:
+					gcode.setValue("N", str(lineNumber))
+					self.changedCommands[lineNumber] = gcode.getAscii()
 				data = gcode.getBinary()
-				self._logger.info(gcode.getAscii())
+				self._logger.info("{0} [{1} + {2}]".format(gcode.getAscii(), len(self.changedCommands), len(self.commandBacklog)))
+
 			# Send command to printer
 			self._printer.get_transport().write(data)
 			
@@ -1708,7 +1746,7 @@ class M3DFioPlugin(
 			
 			# Removed stored value if command was changed
 			if lineNumber in self.changedCommands :
-				self.changedCommands.remove(lineNumber)
+				self.changedCommands.pop(lineNumber)
 	
 			# Set response to contain correct line number
 			response = "ok " + str(lineNumber + self.numberWrapCounter * 0x10000) + '\n'
@@ -1725,7 +1763,7 @@ class M3DFioPlugin(
 			
 			# Removed stored value if command was changed
 			if lineNumber in self.changedCommands :
-				self.changedCommands.remove(lineNumber)
+				self.changedCommands.pop(lineNumber)
 	
 			# Set response to contain correct line number
 			response = "ok " + str(lineNumber + self.numberWrapCounter * 0x10000) + '\n'


### PR DESCRIPTION
  + fixes stutter while printing
  + fixes long pauses with hundreds of G4 commands
  + lets the gcode viewer keep in sync with the print
  - seem to end early with a few commands left in the backlog
    (~10 after a million gcodes, no idea why)
    (shows index out of range for list exception but no backtrace)

---

Given that some commands remain behind at the end this is still work-in-progress. The reason is the exception but the lack of backtrace makes it hard to say where it occurs. Also the right thing would be to do the processing in the queue hook but that needs a patch for octoprint to allow the queue hook to return multiple commands. Here is how it works:

Preprocessing needs to insert new commands into the stream. For this it keeps a backlog of commands that it still needs to print. Both preprocessed and normal commands are added to the backlog to keep them in-order, unless the command is "G4 *, which are used to work off the backlog. When adding prepropcessed commands to the backlog it also adds "G4 *" commands to the printer command queue. It then prints the first command from the backlog keeping track of the linenumer and command for resends. There are as many "G4 *" commands added as are used up to clear the backlog. It should add up to 0 in the end.

Now here is the advantage over the previous code: It does not replace the original command with G4 which leads to stutter in the printer. Instead it replaces the command with the first in the backlog keeping up a steady stream of usefull commands. Not sure why those inserted G4 would start to collect over time. Only idea is that somehow it processes a G4 resulting in emiting 2 G4 but that should grow the run of G4's way faster than observed. Anyway, avoiding the normal G4s already makes the change worth it.