### PR TITLE
raspberry getCpuHardware workaroud

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,24 @@ def package_data_dirs(source, sub_folders):
 
 	return dirs
 
+# Get cpu hardware
+def getCpuHardware() :
+
+	# Check if CPU info exists
+	if os.path.isfile("/proc/cpuinfo") :
+
+		# Read in CPU info
+		for line in open("/proc/cpuinfo") :
+
+			# Check if line contains hardware information
+			if line.startswith("Hardware") and ':' in line :
+
+				# Return CPU hardware
+				return line[line.index(':') + 2 : -1]
+	
+	# Return empty string
+	return ''
+
 def params():
 	# Our metadata, as defined above
 	name = plugin_name
@@ -58,6 +76,7 @@ def params():
 	
 	# Add requirements for using a Raspberry Pi
 	import platform
+	import os
 	if platform.uname()[0].startswith("Linux") and ((platform.uname()[4].startswith("armv6l") and getCpuHardware() == "BCM2708") or (platform.uname()[4].startswith("armv7l") and getCpuHardware() == "BCM2709")) :
 		install_requires.pop()
 		install_requires += ["RPi.GPIO>=0.6.1", '']


### PR DESCRIPTION
getCpuHardware is used in setup.py but defined in __init__.py
this is just dirty fix, so I could install newest version