### PR TITLE
various speed improvements

### DIFF
--- a/shared library source/gcode.cpp
+++ b/shared library source/gcode.cpp
@@ -5,79 +5,128 @@
 
 
 // Definitions
-#define ORDER "NMGXYZE FTSP    IJRD"
+// Offsets                      1111111111 
+//                    0123456.8901....6789
+const char ORDER[] = "NMGXYZE FTSP    IJRD";
+const int ORDERlen = sizeof(ORDER)-1;
+#define _NO 0xFF
+unsigned char orderToOffset[] = {
+  /*    0 nul */ _NO,/*    1 soh */ _NO,/*    2 stx */ _NO,/*    3 etx */ _NO,/*    4 eot */ _NO,/*    5 enq */ _NO,/*    6 ack */ _NO,/*    7 bel */ _NO,
+  /*    8 bs  */ _NO,/*    9 ht  */ _NO,/*   10 nl  */ _NO,/*   11 vt  */ _NO,/*   12 np  */ _NO,/*   13 cr  */ _NO,/*   14 so  */ _NO,/*   15 si  */ _NO,
+  /*   16 dle */ _NO,/*   17 dc1 */ _NO,/*   18 dc2 */ _NO,/*   19 dc3 */ _NO,/*   20 dc4 */ _NO,/*   21 nak */ _NO,/*   22 syn */ _NO,/*   23 etb */ _NO,
+  /*   24 can */ _NO,/*   25 em  */ _NO,/*   26 sub */ _NO,/*   27 esc */ _NO,/*   28 fs  */ _NO,/*   29 gs  */ _NO,/*   30 rs  */ _NO,/*   31 us  */ _NO,
+  /*   32 sp  */ _NO,/*   33  !  */ _NO,/*   34  "  */ _NO,/*   35  #  */ _NO,/*   36  $  */ _NO,/*   37  %  */ _NO,/*   38  &  */ _NO,/*   39  '  */ _NO,
+  /*   40  (  */ _NO,/*   41  )  */ _NO,/*   42  *  */ _NO,/*   43  +  */ _NO,/*   44  ,  */ _NO,/*   45  -  */ _NO,/*   46  .  */ _NO,/*   47  /  */ _NO,
+  /*   48  0  */ _NO,/*   49  1  */ _NO,/*   50  2  */ _NO,/*   51  3  */ _NO,/*   52  4  */ _NO,/*   53  5  */ _NO,/*   54  6  */ _NO,/*   55  7  */ _NO,
+  /*   56  8  */ _NO,/*   57  9  */ _NO,/*   58  :  */ _NO,/*   59  ;  */ _NO,/*   60  <  */ _NO,/*   61  =  */ _NO,/*   62  >  */ _NO,/*   63  ?  */ _NO,
+  /*   64  @  */ _NO,/*   65  A  */ _NO,/*   66  B  */ _NO,/*   67  C  */ _NO,/*   68  D  */  19,/*   69  E  */   6,/*   70  F  */   8,/*   71  G  */   2,
+  /*   72  H  */ _NO,/*   73  I  */  16,/*   74  J  */  17,/*   75  K  */ _NO,/*   76  L  */ _NO,/*   77  M  */   1,/*   78  N  */   0,/*   79  O  */ _NO,
+  /*   80  P  */  11,/*   81  Q  */ _NO,/*   82  R  */  18,/*   83  S  */  10,/*   84  T  */   9,/*   85  U  */ _NO,/*   86  V  */ _NO,/*   87  W  */ _NO,
+  /*   88  X  */   3,/*   89  Y  */   4,/*   90  Z  */   5,/*   91  [  */ _NO,/*   92  \  */ _NO,/*   93  ]  */ _NO,/*   94  ^  */ _NO,/*   95  _  */ _NO,
+  /*   96  `  */ _NO,/*   97  a  */ _NO,/*   98  b  */ _NO,/*   99  c  */ _NO,/*  100  d  */ _NO,/*  101  e  */ _NO,/*  102  f  */ _NO,/*  103  g  */ _NO,
+  /*  104  h  */ _NO,/*  105  i  */ _NO,/*  106  j  */ _NO,/*  107  k  */ _NO,/*  108  l  */ _NO,/*  109  m  */ _NO,/*  110  n  */ _NO,/*  111  o  */ _NO,
+  /*  112  p  */ _NO,/*  113  q  */ _NO,/*  114  r  */ _NO,/*  115  s  */ _NO,/*  116  t  */ _NO,/*  117  u  */ _NO,/*  118  v  */ _NO,/*  119  w  */ _NO,
+  /*  120  x  */ _NO,/*  121  y  */ _NO,/*  122  z  */ _NO,/*  123  {  */ _NO,/*  124  |  */ _NO,/*  125  }  */ _NO,/*  126  ~  */ _NO,/*  127 del */ _NO,
+  _NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,
+  _NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,
+  _NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,
+  _NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,_NO,
+};  
 
 
 // Supporting function implementation
-Gcode::Gcode() {
-
-	// Set parameter value size
-	parameterValue.resize(strlen(ORDER));
-	
+Gcode::Gcode() :
 	// Set inital data type
-	dataType = 0x1080;
+	// TLH Initialization syntax is preferred for constructors.
+	dataType(0x1080)
+{
+	// Set parameter value size
+	parameterValue.resize(ORDERlen);
+	
 }
 
-Gcode::Gcode(Gcode &value) {
-
-	// Copy data type
-	value.dataType = this->dataType;
-	
-	// Copy host command
-	value.hostCommand = this->hostCommand;
-	
-	// Copy parameter values
-	value.parameterValue = this->parameterValue;
-	
+// TLH the assignment statements were all backwards.
+// Also, initialization syntax is preferred for constructors.
+Gcode::Gcode(const Gcode &value) :
 	// Copy original command
-	value.originalCommand = this->originalCommand;
+	originalCommand(value.originalCommand),
+	// Copy parameter values
+	parameterValue(value.parameterValue),
+	// Copy data type
+	dataType(value.dataType),
+	// Copy host command
+	hostCommand(value.hostCommand)
+{
 }
+
+// TLH repeated substrings are expensive
+// TLH a linear search is okay once, but not repeatedly
+//	if((characterOffset = command.find('*')) != string::npos)
+//		// Remove checksum
+//		command = command.substr(0, characterOffset);
+//
+//	// Remove leading and trailing whitespace
+// TLH find_first_not_of is expensive compared to isspace()
+//	if((characterOffset = command.find_first_not_of(" \t\n\r")) != string::npos)
+//		command = command.substr(characterOffset);
+// TLH find_last_not_of is expensive compared to isspace()
+//	if((characterOffset = command.find_last_not_of(" \t\n\r")) != string::npos)
+//		command = command.substr(0, characterOffset + 1);
+//	// Check if command contains a comment
+//	if((characterOffset = command.find(';')) != string::npos)
+//		// Remove comment
+//		command = command.substr(0, characterOffset);
 
 bool Gcode::parseLine(const char *line) {
 
-	// Initialize variables
-	string command = line, currentValue;
-	size_t characterOffset;
-	char parameterIdentifier = 0;
-	const char *parameterOffset;
-	
 	// Reset data type
 	dataType = 0x1080;
 	
 	// Reset parameter values
 	parameterValue.clear();
-	parameterValue.resize(strlen(ORDER));
+	parameterValue.resize(ORDERlen);
 	
 	// Clear host command
 	hostCommand.clear();
 	
 	// Check if command contains a checksum
-	if((characterOffset = command.find('*')) != string::npos)
-	
-		// Remove checksum
-		command = command.substr(0, characterOffset);
-	
-	// Remove leading and trailing whitespace
-	if((characterOffset = command.find_first_not_of(" \t\n\r")) != string::npos)
-		command = command.substr(characterOffset);
-	if((characterOffset = command.find_last_not_of(" \t\n\r")) != string::npos)
-		command = command.substr(0, characterOffset + 1);
-	
-	// Set original command
-	originalCommand = command;
-	
-	// Check if command contains a comment
-	if((characterOffset = command.find(';')) != string::npos)
+	const char *line0 = line;
 
-		// Remove comment
-		command = command.substr(0, characterOffset);
+	// remove leading whitespace
+	while (isspace(*line0))
+		line0++;
+
+	// Remove checksum
+	// If no checksum, set lineStar to end of line
+	const char *lineStar = line0;
+	const char *comment = 0;
+	while (*lineStar && (*lineStar != '*')) {
+		if (*lineStar == ';')
+			comment = lineStar;
+		lineStar++;
+	}
+
+	// Remove leading and trailing whitespace
+	while ((lineStar > line0) && isspace(lineStar[-1]))
+		lineStar--;
+
+	// Set original command
+	originalCommand = string(line0, lineStar - line0);
+	
+	if (comment)
+		lineStar = comment;
 	
 	// Check if command is empty
-	if(!command.length())
-	
+	//	if(!command.length())
+	if (line0 == lineStar)	{
+
 		// Return false
 		return false;
+	}
 	
+	// now(!) we can create the command string
+	string command(line0, lineStar - line0);
+
 	// Check if command is a host command
 	if(command[0] == '@') {
 	
@@ -88,6 +137,12 @@ bool Gcode::parseLine(const char *line) {
 		return true;
 	}
 	
+	// Initialize variables used in parsing the line
+	string currentValue;
+	// size_t characterOffset;
+	unsigned char parameterIdentifier = 0;
+	int parameterOffset;
+	
 	// Go through data
 	for(uint8_t i = 0; i <= command.length(); i++) {
 	
@@ -95,13 +150,13 @@ bool Gcode::parseLine(const char *line) {
 		if(i == 0 || isupper(command[i]) || command[i] == ' ' || !command[i]) {
 		
 			// Check if valid value has been obtained for the parameter
-			if(i && parameterIdentifier != ' ' && (parameterOffset = strchr(ORDER, parameterIdentifier))) {
+			if(i && (parameterOffset = orderToOffset[parameterIdentifier]) != _NO) {
 			
 				// Set data type
-				dataType |= (1 << (parameterOffset - ORDER));
+				dataType |= (1 << parameterOffset);
 			
 				// Store parameter value
-				parameterValue[parameterOffset - ORDER] = currentValue;
+				parameterValue[parameterOffset] = currentValue;
 			}
 			
 			// Reset current value
@@ -113,22 +168,30 @@ bool Gcode::parseLine(const char *line) {
 				// Get string data
 				for(; i < command.length(); i++)
 					currentValue.push_back(command[i]);
-			
+
 				// Remove leading and trailing whitespace
-				if((characterOffset = currentValue.find_first_not_of(" \t\n\r")) != string::npos)
-					currentValue = currentValue.substr(characterOffset);
-				if((characterOffset = currentValue.find_last_not_of(" \t\n\r")) != string::npos)
-					currentValue = currentValue.substr(0, characterOffset + 1);
-				
+				size_t characterOffset1 = currentValue.find_first_not_of(" \t\n\r");
+				if (characterOffset1 == string::npos) characterOffset1 = 0;
+				size_t characterOffset2 = currentValue.find_last_not_of(" \t\n\r");
+				if (characterOffset2 == string::npos) characterOffset2 = currentValue.length();
+				else characterOffset2++;
+				currentValue = currentValue.substr(characterOffset1, characterOffset2 - characterOffset1);
+
+				//				if((characterOffset = currentValue.find_first_not_of(" \t\n\r")) != string::npos)
+				//					currentValue = currentValue.substr(characterOffset);
+				//				if((characterOffset = currentValue.find_last_not_of(" \t\n\r")) != string::npos)
+				//					currentValue = currentValue.substr(0, characterOffset + 1);
+
 				// Set string parameter
 				parameterValue[15] = currentValue;
-				
+
 				// Check if string exists
-				if(!parameterValue[15].empty())
-					
+				if(!parameterValue[15].empty()) {
+
 					// Set data type
 					dataType |= (1 << 15);
-		
+				}
+
 				// Stop parsing line
 				break;
 			}
@@ -154,15 +217,32 @@ bool Gcode::parseLine(const string &line) {
 	return parseLine(line.c_str());
 }
 
+// convert a float from the binary line into its string value
+static inline string grabBinaryFloat(const char *line, uint8_t &index) {
+	// tempFloat is initialized below using bit-fiddling
+	float tempFloat;
+	int32_t *tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
+
+	// Set parameter value from the binary float value
+	*tempPointer = (line[index] & 0xF0) +
+		(line[index] & 0x0F) +
+		(((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) +
+		(((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) +
+		(((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
+
+	// Increment parameter location index
+	index += 4;
+
+	return to_string(tempFloat);
+}
+
 bool Gcode::parseBinary(const char *line) {
 
-	// Initialize variables
-	uint8_t index = 4;
-	int32_t *tempPointer;
-	float tempFloat;
-
 	// Set data type
-	dataType = (line[0] & 0xF0) + (line[0] & 0x0F) + (((line[1] & 0xF0) + (line[1] & 0x0F)) << 8) + (((line[2] & 0xF0) + (line[2] & 0x0F)) << 16) + (((line[3] & 0xF0) + (line[3] & 0x0F)) << 24);
+	dataType = (line[0] & 0xFF) +
+	  (((line[1] & 0xFF)) << 8) +
+	  (((line[2] & 0xFF)) << 16) +
+	  (((line[3] & 0xFF)) << 24);
 	
 	// Check if command contains no data
 	if(!dataType || dataType == 0x1080)
@@ -172,11 +252,14 @@ bool Gcode::parseBinary(const char *line) {
 	
 	// Reset parameter values
 	parameterValue.clear();
-	parameterValue.resize(strlen(ORDER));
+	parameterValue.resize(ORDERlen);
 	
 	// Clear host command
 	hostCommand.clear();
 	
+	// Initialize parameter location index
+	uint8_t index = 4;
+
 	// Check if command contains a string parameter
 	if(dataType & (1 << 15))
 	
@@ -187,7 +270,7 @@ bool Gcode::parseBinary(const char *line) {
 	if(dataType & 1) {
 	
 		// Set parameter value
-		parameterValue[0] = to_string((line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8));
+		parameterValue[0] = to_string((line[index] & 0xFF) + ((line[index + 1] & 0xFF) << 8));
 		
 		// Increment parameter location index
 		index += 2;
@@ -197,7 +280,7 @@ bool Gcode::parseBinary(const char *line) {
 	if(dataType & (1 << 1)) {
 	
 		// Set parameter value
-		parameterValue[1] = to_string((line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8));
+		parameterValue[1] = to_string((line[index] & 0xFF) + (((line[index + 1] & 0xFF)) << 8));
 		
 		// Increment parameter location index
 		index += 2;
@@ -207,7 +290,7 @@ bool Gcode::parseBinary(const char *line) {
 	if(dataType & (1 << 2)) {
 	
 		// Set parameter value
-		parameterValue[2] = to_string((line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8));
+		parameterValue[2] = to_string((line[index] & 0xFF) + ((line[index + 1] & 0xFF) << 8));
 		
 		// Increment parameter location index
 		index += 2;
@@ -215,69 +298,34 @@ bool Gcode::parseBinary(const char *line) {
 	
 	// Check if command contains an X value
 	if(dataType & (1 << 3)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[3] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[3] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a Y value
 	if(dataType & (1 << 4)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[4] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[4] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a Z value
 	if(dataType & (1 << 5)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[5] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[5] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains an E value
 	if(dataType & (1 << 6)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[6] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[6] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains an F value
 	if(dataType & (1 << 8)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[8] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[8] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a T value
 	if(dataType & (1 << 9)) {
 	
 		// Set parameter value
-		parameterValue[9] = to_string((line[index] & 0xF0) + (line[index] & 0x0F));
+		parameterValue[9] = to_string(line[index] & 0xFF);
 		
 		// Increment parameter location index
 		index++;
@@ -287,7 +335,10 @@ bool Gcode::parseBinary(const char *line) {
 	if(dataType & (1 << 10)) {
 	
 		// Set parameter value
-		parameterValue[10] = to_string((line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24));
+		parameterValue[10] = to_string((line[index] & 0xFF) +
+					       ((line[index + 1] & 0xFF) << 8) +
+					       ((line[index + 2] & 0xFF) << 16) +
+					       ((line[index + 3] & 0xFF) << 24));
 		
 		// Increment parameter location index
 		index += 4;
@@ -297,7 +348,10 @@ bool Gcode::parseBinary(const char *line) {
 	if(dataType & (1 << 11)) {
 	
 		// Set parameter value
-		parameterValue[11] = to_string((line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24));
+		parameterValue[11] = to_string((line[index] & 0xFF) +
+					       ((line[index + 1] & 0xFF) << 8) +
+					       ((line[index + 2] & 0xFF) << 16) +
+					       ((line[index + 3] & 0xFF) << 24));
 		
 		// Increment parameter location index
 		index += 4;
@@ -305,57 +359,29 @@ bool Gcode::parseBinary(const char *line) {
 	
 	// Check if command contains an I value
 	if(dataType & (1 << 16)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[16] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[16] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a J value
 	if(dataType & (1 << 17)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[17] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[17] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains an R value
 	if(dataType & (1 << 18)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[18] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[18] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a D value
 	if(dataType & (1 << 19)) {
-	
-		// Set parameter value
-		tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-		*tempPointer = (line[index] & 0xF0) + (line[index] & 0x0F) + (((line[index + 1] & 0xF0) + (line[index + 1] & 0x0F)) << 8) + (((line[index + 2] & 0xF0) + (line[index + 2] & 0x0F)) << 16) + (((line[index + 3] & 0xF0) + (line[index + 3] & 0x0F)) << 24);
-		parameterValue[19] = to_string(tempFloat);
-		
-		// Increment parameter location index
-		index += 4;
+		parameterValue[19] = grabBinaryFloat(line, index);
 	}
 	
 	// Check if command contains a string parameter
 	if(dataType & (1 << 15))
 	
 		// Set string parameter value
-		for(uint8_t i = 0; i < (line[4] & 0xF0) + (line[4] & 0x0F); i++)
+		for(uint8_t i = 0; i < (line[4] & 0xFF); i++)
 			parameterValue[15].push_back(line[index + i]);
 	
 	// Set original command
@@ -371,6 +397,32 @@ string Gcode::getOriginalCommand() const {
 	return originalCommand;
 }
 
+// Set 2 byte integer parameter value
+inline static void pushBackInt16(vector<uint8_t> &request, const string &value) {
+	int32_t tempNumber = stoi(value);
+	request.push_back(tempNumber & 0xFF);
+	request.push_back((tempNumber >> 8) & 0xFF);
+}
+
+// Set 4 byte float parameter value
+inline static void pushBackFloat(vector<uint8_t> &request, const string &value) {
+	float tempFloat = stof(value);
+	int32_t *tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
+	request.push_back(*tempPointer & 0xFF);
+	request.push_back((*tempPointer >> 8) & 0xFF);
+	request.push_back((*tempPointer >> 16) & 0xFF);
+	request.push_back((*tempPointer >> 24) & 0xFF);
+}
+
+// Set 4 byte integer parameter value
+inline static void pushBackRoundedInt32(vector<uint8_t> &request, const string &value) {
+	int32_t tempNumber = static_cast<int>(round(stod(value)));
+	request.push_back(tempNumber & 0xFF);
+	request.push_back((tempNumber >> 8) & 0xFF);
+	request.push_back((tempNumber >> 16) & 0xFF);
+	request.push_back((tempNumber >> 24) & 0xFF);
+}
+
 vector<uint8_t> Gcode::getBinary() const {
 
 	// Initialize request
@@ -378,19 +430,12 @@ vector<uint8_t> Gcode::getBinary() const {
 	
 	// Check if host command
 	if(!hostCommand.empty())
-	
 		// Set request to host command
 		for(uint8_t i = 0; i < hostCommand.length(); i++)
 			request.push_back(hostCommand[i]);
 	
 	// Otherwise
 	else {
-	
-		// Initialize variables
-		uint16_t sum1 = 0, sum2 = 0;
-		int32_t tempNumber, *tempPointer;
-		float tempFloat;
-		
 		// Fill first four bytes of request to data type
 		request.push_back(dataType);
 		request.push_back(dataType >> 8);
@@ -398,183 +443,97 @@ vector<uint8_t> Gcode::getBinary() const {
 		request.push_back(dataType >> 24);
 	
 		// Check if command contains a string parameter
-		if(!parameterValue[15].empty())
-	
+		if(!parameterValue[15].empty()) {	
 			// Set fifth byte of request to string length
 			request.push_back(parameterValue[15].length());
+		}
 		
 		// Check if command contains an N value
 		if(!parameterValue[0].empty()) {
-		
-			// Set 2 byte integer parameter value
-			tempNumber = stoi(parameterValue[0]);
-			request.push_back(tempNumber & 0xFF);
-			request.push_back((tempNumber >> 8) & 0xFF);
+			pushBackInt16(request, parameterValue[0]);
 		}
 		
 		// Check if command contains an M value
 		if(!parameterValue[1].empty()) {
-		
-			// Set 2 byte integer parameter value
-			tempNumber = stoi(parameterValue[1]);
-			request.push_back(tempNumber & 0xFF);
-			request.push_back((tempNumber >> 8) & 0xFF);
+			pushBackInt16(request, parameterValue[1]);
 		}
 		
-		// CCheck if command contains a G value
+		// Check if command contains a G value
 		if(!parameterValue[2].empty()) {
-		
-			// Set 2 byte integer parameter value
-			tempNumber = stoi(parameterValue[2]);
-			request.push_back(tempNumber & 0xFF);
-			request.push_back((tempNumber >> 8) & 0xFF);
+			pushBackInt16(request, parameterValue[2]);
 		}
 		
 		// Check if command contains an X value
 		if(!parameterValue[3].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[3]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[3]);
 		}
 		
 		// Check if command contains a Y value
 		if(!parameterValue[4].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[4]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[4]);
 		}
 		
 		// Check if command contains a Z value
 		if(!parameterValue[5].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[5]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[5]);
 		}
 		
 		// Check if command contains an E value
 		if(!parameterValue[6].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[6]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[6]);
 		}
 		
 		// Check if command contains an F value
 		if(!parameterValue[8].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[8]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[8]);
 		}
 		
 		// Check if command contains a T value
 		if(!parameterValue[9].empty()) {
-		
 			// Set 1 byte integer parameter value
-			tempNumber = stoi(parameterValue[9]);
+			int32_t tempNumber = stoi(parameterValue[9]);
 			request.push_back(tempNumber & 0xFF);
 		}
 		
 		// Check if command contains an S value
 		if(!parameterValue[10].empty()) {
-			
-			// Set 4 byte integer parameter value
-			tempNumber = static_cast<int>(round(stod(parameterValue[10])));
-			request.push_back(tempNumber & 0xFF);
-			request.push_back((tempNumber >> 8) & 0xFF);
-			request.push_back((tempNumber >> 16) & 0xFF);
-			request.push_back((tempNumber >> 24) & 0xFF);
+			pushBackRoundedInt32(request, parameterValue[10]);
 		}
 		
 		// Check if command contains a P value
 		if(!parameterValue[11].empty()) {
-			
-			// Set 4 byte integer parameter value
-			tempNumber = static_cast<int>(round(stod(parameterValue[11])));
-			request.push_back(tempNumber & 0xFF);
-			request.push_back((tempNumber >> 8) & 0xFF);
-			request.push_back((tempNumber >> 16) & 0xFF);
-			request.push_back((tempNumber >> 24) & 0xFF);
+			pushBackRoundedInt32(request, parameterValue[11]);
 		}
 		
 		// Check if command contains an I value
 		if(!parameterValue[16].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[16]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[16]);
 		}
 		
 		// Check if command contains a J value
 		if(!parameterValue[17].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[17]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[17]);
 		}
 		
 		// Check if command contains an R value
 		if(!parameterValue[18].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[18]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[18]);
 		}
 		
 		// Check if command contains a D value
 		if(!parameterValue[19].empty()) {
-			
-			// Set 4 byte float parameter value
-			tempFloat = stof(parameterValue[19]);
-			tempPointer = reinterpret_cast<int32_t *>(&tempFloat);
-			request.push_back(*tempPointer & 0xFF);
-			request.push_back((*tempPointer >> 8) & 0xFF);
-			request.push_back((*tempPointer >> 16) & 0xFF);
-			request.push_back((*tempPointer >> 24) & 0xFF);
+			pushBackFloat(request, parameterValue[19]);
 		}
 		
 		// Check if command contains a string
 		if(!parameterValue[15].empty())
-		
 			// Set string parameter value
 			for(uint8_t i = 0; i < parameterValue[15].length(); i++)
 				request.push_back(parameterValue[15][i]);
 		
+		// Initialize sum variables
+		uint16_t sum1 = 0, sum2 = 0;
+
 		// Go through all values
 		for(uint8_t index = 0; index < request.size(); index++) {
 
@@ -604,7 +563,7 @@ string Gcode::getAscii() const {
 	string request;
 	
 	// Go through all values
-	for(uint8_t i = 0; i < strlen(ORDER); i++)
+	for(uint8_t i = 0; i < ORDERlen; i++) {
 		
 		// Check if command contains value and value is valid
 		if(dataType & (1 << i) && 0xF0F7F & (1 << i)) {
@@ -618,7 +577,7 @@ string Gcode::getAscii() const {
 				// Append string to request
 				request += parameterValue[15] + ' ';
 		}
-	
+	}
 	// Remove last space from request
 	if(!request.empty())
 		request.pop_back();
@@ -635,16 +594,17 @@ uint32_t Gcode::getDataType() const {
 
 bool Gcode::hasParameter(char parameter) const {
 
-	// Check if parameter isn't a space
-	if(parameter != ' ') {
+  // TLH checking twice
+  //	// Check if parameter isn't a space
+  //	if(parameter != ' ') {
+
+	// Check if parameter is valid
+	int parameterOffset = orderToOffset[(unsigned char)parameter];
+	if(parameterOffset != _NO)
 	
-		// Check if parameter is valid
-		const char *parameterOffset = strchr(ORDER, parameter);
-		if(parameterOffset)
-	
-			// Return if value is set
-			return dataType & (1 << (parameterOffset - ORDER));
-	}
+		// Return if value is set
+		return dataType & (1 << parameterOffset);
+  //	}
 	
 	// Return false
 	return false;
@@ -652,40 +612,42 @@ bool Gcode::hasParameter(char parameter) const {
 
 void Gcode::removeParameter(char parameter) {
 
-	// Check if parameter isn't a space
-	if(parameter != ' ') {
-	
+  // TLH checking twice
+  //	// Check if parameter isn't a space
+  //	if(parameter != ' ') {
+
 		// Check if parameter is valid
-		const char *parameterOffset = strchr(ORDER, parameter);
-		if(parameterOffset) {
-		
+		int parameterOffset = orderToOffset[(unsigned char) parameter];
+		if(parameterOffset != _NO) {
+
 			// Clear data type
-			dataType &= ~(1 << (parameterOffset - ORDER));
-			
+			dataType &= ~(1 << parameterOffset);
+
 			// Clear parameter value
-			parameterValue[parameterOffset - ORDER].clear();
-		
+			parameterValue[parameterOffset].clear();
+
 			// Check if command is now empty
 			if(dataType == 0x1080)
-		
+
 				// Clear original command
 				originalCommand = "";
 		}
-	}
+  //	}
 }
 
 bool Gcode::hasValue(char parameter) const {
 
-	// Check if parameter isn't a space
-	if(parameter != ' ') {
+  // TLH checking twice
+  //	// Check if parameter isn't a space
+  //	if(parameter != ' ') {
 	
 		// Check if parameter is valid
-		const char *parameterOffset = strchr(ORDER, parameter);
-		if(parameterOffset)
+		int parameterOffset = orderToOffset[(unsigned char)parameter];
+		if(parameterOffset != _NO)
 	
 			// Return if parameter's value isn't empty
-			return !parameterValue[parameterOffset - ORDER].empty();
-	}
+			return !parameterValue[parameterOffset].empty();
+  //	}
 	
 	// Return false
 	return false;
@@ -693,16 +655,17 @@ bool Gcode::hasValue(char parameter) const {
 
 string Gcode::getValue(char parameter) const {
 
-	// Check if parameter isn't a space
-	if(parameter != ' ') {
+  // TLH checking twice
+  //	// Check if parameter isn't a space
+  //	if(parameter != ' ') {
 	
 		// Check if parameter is valid
-		const char *parameterOffset = strchr(ORDER, parameter);
-		if(parameterOffset)
+		int parameterOffset = orderToOffset[(unsigned char)parameter];
+		if(parameterOffset != _NO)
 	
 			// Return parameter's value
-			return parameterValue[parameterOffset - ORDER];
-	}
+			return parameterValue[parameterOffset];
+  //	}
 	
 	// Return empty
 	return "";
@@ -710,20 +673,21 @@ string Gcode::getValue(char parameter) const {
 
 void Gcode::setValue(char parameter, const string &value) {
 
-	// Check if parameter isn't a space
-	if(parameter != ' ') {
+  // TLH checking twice
+  //	// Check if parameter isn't a space
+  //	if(parameter != ' ') {
 	
 		// Check if parameter is valid
-		const char *parameterOffset = strchr(ORDER, parameter);
-		if(parameterOffset) {
+		int parameterOffset = orderToOffset[(unsigned char) parameter];
+		if(parameterOffset != _NO) {
 	
 			// Set data type
-			dataType |= (1 << (parameterOffset - ORDER));
+			dataType |= (1 << parameterOffset);
 	
 			// Set parameter value
-			parameterValue[parameterOffset - ORDER] = value;
+			parameterValue[parameterOffset] = value;
 		}
-	}
+  //	}
 }
 
 bool Gcode::hasString() const {
@@ -754,7 +718,7 @@ void Gcode::clear() {
 
 	// Set parameter value size
 	parameterValue.clear();
-	parameterValue.resize(strlen(ORDER));
+	parameterValue.resize(ORDERlen);
 	
 	// Clear host command
 	hostCommand.clear();


### PR DESCRIPTION
Here are my speed improvements for gcode that I've been promising you. :-)

My tests with the old gcode.cpp vs the new gcode.cpp show that it runs 15-25% faster. Here is a test with a 34458619 gcode file. The copy() test does parseline and an ostream <<. The mod_center() test does a parseline, gets and sets the G/X/Y/E values, and an ostream <<. The first run is with "g++ -pg" and the 2nd run is without "-pg":

==> n1/big.out-old <==
copy(big.gcode) took 111.47 seconds of processing
mod_center(big.gcode) took 220.44 seconds of processing

==> n1/big.out-new <==
copy(big.gcode) took 83.72 seconds of processing
mod_center(big.gcode) took 181.44 seconds of processing

83.72 / 111.47 = .75105 = 25% improvement
181.44 / 220.44 = .82308 = 18% improvement

==> n2/big.out-old <==
copy(big.gcode) took 117.89 seconds of processing
mod_center(big.gcode) took 229.54 seconds of processing

==> n2/big.out-new <==
copy(big.gcode) took 99.76 seconds of processing
mod_center(big.gcode) took 200.74 seconds of processing

99.76 / 117.89 = .84621 = 15% improvement
200.74 / 229.54 = .87453 = 13% improvement
